### PR TITLE
Hash key can be Number as well as String in Table.remove

### DIFF
--- a/src/lib/aws-translators.coffee
+++ b/src/lib/aws-translators.coffee
@@ -23,7 +23,7 @@ module.exports.getKeySchema = (tableDescription) ->
 
 module.exports.deleteItem = (params, options, callback, keySchema) ->
   if !_.isObject params
-    params = hash: params
+    params = hash: params+''
 
   key = {}
   key[keySchema.hashKeyName] = {}


### PR DESCRIPTION
The last request was in error. Amazon expects numeric hash keys in the form {'N':String} rather than {'N':Number}.
