### PR TITLE
This will allow users to connect to local dynamo

### DIFF
--- a/src/dynasty.coffee
+++ b/src/dynasty.coffee
@@ -19,12 +19,16 @@ Table = lib.Table
 
 class Dynasty
 
-  constructor: (credentials) ->
+  constructor: (credentials, url) ->
     debug "dynasty constructed."
     credentials.region = credentials.region || 'us-east-1'
 
     # Lock API version
     credentials.apiVersion = '2012-08-10'
+
+    if url and _.isString url
+      debug "connecting to local dynamo at #{url}"
+      credentials.endpoint = new aws.Endpoint url
 
     aws.config.update credentials
 
@@ -129,4 +133,4 @@ class Dynasty
 
     @dynamo.listTablesAsync(awsParams)
 
-module.exports = (credentials) -> new Dynasty(credentials)
+module.exports = (credentials, url) -> new Dynasty(credentials, url)


### PR DESCRIPTION
In order to connect to local dynamo (see #36), you just pass an additional string argument, url, to the dynasty constructor:

``` javascript
var credentials = {
    accessKeyId: '<YOUR ACCESS_KEY_ID>',
    secretAccessKey: '<YOUR_SECRET_ACCESS_KEY>'
};

var dynasty = require('dynasty')(credentials, 'http://localhost:4566');
```

I would recommend setting up local dynamo using: https://github.com/Medium/local-dynamo
