### PR TITLE
Fix a bug preventing key schemas being added to GSI

### DIFF
--- a/src/dynasty.coffee
+++ b/src/dynasty.coffee
@@ -98,9 +98,10 @@ class Dynasty
 
     # Add GlobalSecondaryIndexes to awsParams if provided
     if params.global_secondary_indexes?
+      awsParams.GlobalSecondaryIndexes = []
       # Verify valid GSI
-      for global_secondary_index in params.global_secondary_indexes
-        key_schema = global_secondary_index.key_schema
+      for index in params.global_secondary_indexes
+        key_schema = index.key_schema
         # Must provide hash type
         unless key_schema.hash?
           throw TypeError 'Missing hash index for GlobalSecondaryIndex'
@@ -111,26 +112,32 @@ class Dynasty
         # Providing 2 types but the second isn't range type
         if typesProvided.length is 2 and not key_schema.range?
           throw TypeError 'Two types provided but the second isn\'t range'
-      awsParams.GlobalSecondaryIndexes = ({
-        IndexName: index.index_name
-        KeySchema: ({
-          AttributeName: key[0]
-          KeyType: type.toUpperCase()
-        } for key in index.key_schema)
-        Projection:
-          ProjectionType: index.projection_type.toUpperCase()
-        # Use the provided or default throughput
-        ProvisionedThroughput: unless index.provisioned_throughput? then awsParams.ProvisionedThroughput else {
-          ReadCapacityUnits: index.provisioned_throughput.read
-          WriteCapacityUnits: index.provisioned_throughput.write
+      # Push each index
+      for index in params.global_secondary_indexes
+        keySchema = []
+        for type, keys of index.key_schema
+          keySchema.push({
+            AttributeName: key[0]
+            KeyType: type.toUpperCase()
+          }) for key in keys
+        awsParams.GlobalSecondaryIndexes.push {
+          IndexName: index.index_name
+          KeySchema: keySchema
+          Projection:
+            ProjectionType: index.projection_type.toUpperCase()
+          # Use the provided or default throughput
+          ProvisionedThroughput: unless index.provisioned_throughput? then awsParams.ProvisionedThroughput else {
+            ReadCapacityUnits: index.provisioned_throughput.read
+            WriteCapacityUnits: index.provisioned_throughput.write
+          }
         }
-      } for type, index of params.global_secondary_indexes)
-      # Add key name for each GlobalSecondaryIndex to attributeDefinitions
-      for global_secondary_index in params.global_secondary_indexes
-        awsParams.AttributeDefinitions = awsParams.AttributeDefinitions.concat ({
-          AttributeName: key[0]
-          AttributeType: typeToAwsType[key[1]]
-        } for key in global_secondary_index.key_schema)
+        # Add key name to attributeDefinitions
+        for type, keys of index.key_schema
+          for key in keys
+            awsParams.AttributeDefinitions.push {
+              AttributeName: key[0]
+              AttributeType: typeToAwsType[key[1]]
+            }
 
     console.log "creating table with params #{JSON.stringify(awsParams, null, 4)}"
 


### PR DESCRIPTION
The `key_schema` field when creating a Global Secondary Index was being added as an empty array. This was because originally I had enforced `hash` type keys, and did not allow `range` keys.

The example in the last [PR](https://github.com/victorquinn/dynasty/pull/55) included the intented use for adding both `hash` and `range` keys, but the code for allowing Dynasty to respond to this change was not commited.

The pull request fixes this.