### PR TITLE
Fixed bug when translating from numbers when they are zero

### DIFF
--- a/src/lib/data-translators.coffee
+++ b/src/lib/data-translators.coffee
@@ -29,7 +29,7 @@ fromDynamo = (dbObj) ->
       return dbObj.S
     else if(dbObj.SS)
       return dbObj.SS
-    else if(dbObj.N)
+    else if(dbObj.N?)
       return parseFloat(dbObj.N)
     else if(dbObj.NS)
       return _.map(dbObj.NS, parseFloat)

--- a/test/src/data-translators.coffee
+++ b/test/src/data-translators.coffee
@@ -87,3 +87,23 @@ describe 'fromDynamo()', () ->
 
   it 'converts dynamo NULLs to javascript nulls' , () ->
     expect(dataTrans.fromDynamo({NULL: true})).to.be.null
+
+  it 'converts string lists correctly', () ->
+    dynamoData =
+      L: [
+        S: 'foo'
+      ,
+        S: 'bar'
+      ]
+    expect(dataTrans.fromDynamo(dynamoData)).to.eql(['foo', 'bar'])
+
+  it 'converts numbered lists correctly',() ->
+    dynamoData =
+      M:
+        foo:
+          L: [
+            N: 0
+          ,
+            N: 1
+          ]
+    expect(dataTrans.fromDynamo(dynamoData)).to.eql({foo: [0, 1]})


### PR DESCRIPTION
Because `dbObj.N` would evaluate to false when `dbObj.N = 0` we need to use the existence operator or bad things happen. 