### PR TITLE
Added ability to specify exclusive start key on scan

### DIFF
--- a/src/lib/aws-translators.coffee
+++ b/src/lib/aws-translators.coffee
@@ -123,6 +123,11 @@ module.exports.scan = (params, options, callback, keySchema) ->
     TotalSegments: params.totalSegment
     Segment: params.segment
 
+  if params.ExclusiveStartKey?
+    awsParams.ExclusiveStartKey = {}
+    for prop, val of params.ExclusiveStartKey
+      awsParams.ExclusiveStartKey[prop] = dataTrans.toDynamo val
+
   buildFilters(awsParams.ScanFilter, params.filters)
 
   @parent.dynamo.scanAsync(awsParams)


### PR DESCRIPTION
This is a minor change that enables users to perform the actions the documentation says they should be able to. Users should be given the ability to iterate across a given table.
