### PR TITLE
Allow 'scan' method to return all attributes if none are specified

### DIFF
--- a/src/lib/aws-translators.coffee
+++ b/src/lib/aws-translators.coffee
@@ -117,8 +117,7 @@ module.exports.scan = (params, options, callback, keySchema) ->
   awsParams =
     TableName: @name
     ScanFilter: {}
-    Select: 'SPECIFIC_ATTRIBUTES'
-    AttributesToGet: params.attrsGet || [keySchema.hashKeyName]
+    AttributesToGet: params.attrsGet || null
     Limit: params.limit
     TotalSegments: params.totalSegment
     Segment: params.segment


### PR DESCRIPTION
According to Amazon's DOCS (http://docs.aws.amazon.com/sdkfornet1/latest/apidocs/html/P_Amazon_DynamoDBv2_Model_QueryRequest_AttributesToGet.htm) 

> You cannot use both AttributesToGet and Select together in a Query request, unless the value for Select is SPECIFIC_ATTRIBUTES. (This usage is equivalent to specifying AttributesToGet without any value for Select.)

I simply removed the `Select` key and have it defaulting to pull all attributes or any specified with the `attrsGet` key.

Addressed issue #51 