### PR TITLE
Averting Connection Error

### DIFF
--- a/docs/getting-started/instantiate.md
+++ b/docs/getting-started/instantiate.md
@@ -11,7 +11,7 @@ instance that is not on AWS. For example if you are running Dynamo
 you would instantiate it as follows:
 
 ```js
-var dynasty = require('dynasty')(credentials, 'localhost:8000');
+var dynasty = require('dynasty')(credentials, 'http://localhost:8000');
 ```
 
 Note, you still have to provide credentials, even if running locally doesn't


### PR DESCRIPTION
In testing out Dynasty on a local instance of DynamoDB, I took this page at its word and used the DB address `localhost:8000` which threw a nasty error.  A quick look at #88 revealed the string must be `http://localhost:8000` instead!