### PR TITLE
Fixing GSI translators. Fixes #98

### DIFF
--- a/src/dynasty.coffee
+++ b/src/dynasty.coffee
@@ -118,9 +118,9 @@ class Dynasty
         keySchema = []
         for type, keys of index.key_schema
           keySchema.push({
-            AttributeName: key[0]
+            AttributeName: keys[0]
             KeyType: type.toUpperCase()
-          }) for key in keys
+          })
         awsParams.GlobalSecondaryIndexes.push {
           IndexName: index.index_name
           KeySchema: keySchema
@@ -134,11 +134,10 @@ class Dynasty
         }
         # Add key name to attributeDefinitions
         for type, keys of index.key_schema
-          for key in keys
-            awsParams.AttributeDefinitions.push {
-              AttributeName: key[0]
-              AttributeType: typeToAwsType[key[1]]
-            }
+          awsParams.AttributeDefinitions.push {
+            AttributeName: keys[0]
+            AttributeType: typeToAwsType[keys[1]]
+          }
 
     debug "creating table with params #{JSON.stringify(awsParams, null, 4)}"
 

--- a/src/dynasty.coffee
+++ b/src/dynasty.coffee
@@ -137,7 +137,7 @@ class Dynasty
           awsParams.AttributeDefinitions.push {
             AttributeName: keys[0]
             AttributeType: typeToAwsType[keys[1]]
-          }
+          } if awsParams.AttributeDefinitions.filter( (ad) -> ad.AttributeName == keys[0] ).length == 0
 
     debug "creating table with params #{JSON.stringify(awsParams, null, 4)}"
 

--- a/test/src/base.coffee
+++ b/test/src/base.coffee
@@ -51,13 +51,16 @@ describe 'Dynasty', () ->
         expect(promise).to.be.an('object')
       
       it 'should accept global secondary indexes', () ->
+        hash = chance.name()
+        range = chance.name()
         promise = @dynasty.create chance.name(),
           key_schema:
-            hash: [chance.name(), 'string']
+            hash: [hash, 'string']
+            range: [range, 'string']
           global_secondary_indexes: [
             index_name: chance.name()
             key_schema:
-              hash: [chance.name(), 'string']
+              hash: [range, 'string']
             projection_type: 'all'
           ]
 

--- a/test/src/base.coffee
+++ b/test/src/base.coffee
@@ -49,6 +49,19 @@ describe 'Dynasty', () ->
             range: [chance.name(), 'string']
 
         expect(promise).to.be.an('object')
+      
+      it 'should accept global secondary indexes', () ->
+        promise = @dynasty.create chance.name(),
+          key_schema:
+            hash: [chance.name(), 'string']
+          global_secondary_indexes: [
+            index_name: chance.name()
+            key_schema:
+              hash: [chance.name(), 'string']
+            projection_type: 'all'
+          ]
+
+        expect(promise).to.be.an('object')
 
   describe 'Table', () ->
 


### PR DESCRIPTION
Fixing the AWS translator for table creation when GSIs are provided. It was creating attributes definitions with single letters and also duplicating the definition when the attribute already existed.

Added some tests as well.