### PR TITLE
Remove hardcoded us-east-1 region

### DIFF
--- a/src/dynasty.coffee
+++ b/src/dynasty.coffee
@@ -22,7 +22,6 @@ class Dynasty
 
   constructor: (credentials, url) ->
     debug "dynasty constructed."
-    credentials.region = 'us-east-1'
     # Default to credentials passed in, if any
     if credentials.region
       credentials.region = credentials.region


### PR DESCRIPTION
Remove the line that overwrites the `region` property of the credentials and allows the logic to work as expected.