### PR TITLE
Permit SDK Credential Precedence

### DIFF
--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,5 +1,21 @@
 ## credentials
 
+There are several ways in Dynasty to supply your credentials to Amazon DynamoDB. Some of these are more secure and others afford greater convenience while developing an application. 
+
+Here are the ways you can supply your credentials in order of recommendation:
+
+- Loaded from AWS Identity and Access Management (IAM) roles for Amazon EC2 or ECS
+
+- Loaded from the shared credentials file (~/.aws/credentials)
+
+- Loaded from environment variables
+
+- Explicitly provided in the Dynasty constructor
+
+Please see the AWS Node.js SDK documentation to learn more about specifying [credential][SDK] and [region][Region] values.
+
+### Explicitly providing your credentials and region
+
 Amazon uses a 2 key system for access to its APIs. They are the *Access Key Id* and
 the *Secret Access Key*.
 
@@ -9,7 +25,8 @@ values:
 ```js
 var credentials = {
     accessKeyId: '<YOUR ACCESS_KEY_ID>',
-    secretAccessKey: '<YOUR_SECRET_ACCESS_KEY>'
+    secretAccessKey: '<YOUR_SECRET_ACCESS_KEY>',
+    region: '<YOUR_REGION_VALUE>'
 };
 ```
 
@@ -22,9 +39,6 @@ if you haven't already.
 
 [More info on getting started with credentials][GettingStarted]
 
-Recommend storing these credentials in environment variables and loading them
-in a config file.
-
 So rather than the text strings appearing in your code (and worse, getting
 committed to your repo!), set them as environment variables and load them
 in your code as follows:
@@ -33,10 +47,9 @@ in your code as follows:
 var credentials = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+    region: process.env.AWS_DEFAULT_REGION
 };
 ```
-
-Can optionally specify a region. If none is specified, *us-east-1* is the default.
 
 For example, to use the *eu-west-1* region based in Ireland, use the following
 credentials:
@@ -52,5 +65,7 @@ var credentials = {
 Only this short string is necessary to specify the region, **Dynasty** will convert
 it into the full endpoint URL for you.
 
+[SDK]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
+[Region]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
 [AWS]: https://console.aws.amazon.com/iam/home?#users
 [GettingStarted]: http://docs.aws.amazon.com/IAM/latest/UserGuide/IAMGettingStarted.html

--- a/src/dynasty.coffee
+++ b/src/dynasty.coffee
@@ -22,20 +22,6 @@ class Dynasty
 
   constructor: (credentials, url) ->
     debug "dynasty constructed."
-    # Default to credentials passed in, if any
-    if credentials.region
-      credentials.region = credentials.region
-    # Fall back on env variables
-    else if process.env.AWS_DEFAULT_REGION
-      credentials.region = process.env.AWS_DEFAULT_REGION
-    else
-      credentials.region = 'us-east-1'
-
-    if !credentials.accessKeyId
-      credentials.accessKeyId = process.env.AWS_ACCESS_KEY_ID
-
-    if !credentials.secretAccessKey
-      credentials.accessKeyId = process.env.AWS_SECRET_ACCESS_KEY
 
     # Lock API version
     credentials.apiVersion = '2012-08-10'

--- a/test/src/base.coffee
+++ b/test/src/base.coffee
@@ -14,6 +14,7 @@ getCredentials = () ->
     pool: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   secretAccessKey: chance.string
     length: 40
+  region: 'us-east-1'
 
 describe 'Dynasty', () ->
   describe 'Base', () ->


### PR DESCRIPTION
This PR directly address issue #87.

By not directly loading environment variables into the `credentials` hash passed to the `DynamoDB` object, we are able to use the order of precedence provided by the AWS Node.js SDK.

Specifically, credentials will be loaded in the following order of precedence:

1. If the `accessKeyId`, `secretAccessKey`, and `region` keys are included in the credentials hash passed into Dynasty, they will be used.

2. If not the above, then the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` environmental variables will be used.

3. If not any of the above, then credentials will be pulled from the default SDK credential file at `~/.aws/credentials`.

4. If not any of the above, then credentials will be loaded from AWS Identity and Access Management (IAM) roles for Amazon EC2 or ECS.

More information here - https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html

I think this will make Dynasty more useful in Lambda functions, as well as in general.

Thanks for your consideration.